### PR TITLE
子オプションを開いたときBoolean値だけ必ずオフに見える不具合の対応

### DIFF
--- a/Modules/OptionItems/BooleanOptionItem.cs
+++ b/Modules/OptionItems/BooleanOptionItem.cs
@@ -43,7 +43,7 @@ namespace TownOfHost
         // Getter
         public override string GetString()
         {
-            return Translator.GetString(GetBool() ? TEXT_true : TEXT_false);
+            return Translator.GetString(GetValue() % 2 == 1 ? TEXT_true : TEXT_false);
         }
 
         // Setter


### PR DESCRIPTION
GetBoolの場合、親オプションのBool値に影響されるためGetValueで判定する形に変更