### PR TITLE
InTaskのリセット漏れを修正

### DIFF
--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -21,7 +21,10 @@ namespace TownOfHost
         public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ref EndGameResult endGameResult)
         {
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+            //GameStatesのリセット
             GameStates.InGame = false;
+            GameStates.InTask = false;
 
             Logger.Info("-----------ゲーム終了-----------", "Phase");
             if (!GameStates.IsModHost) return;


### PR DESCRIPTION
InTaskのリセットをしていなかったため次のゲームがInTask=trueで始まっていた